### PR TITLE
Fix mnesia macros

### DIFF
--- a/include/mnesia-macros.lfe
+++ b/include/mnesia-macros.lfe
@@ -26,8 +26,8 @@
   ((record-table-name '())
     `(create-table ,record-table-name (#(type set))))
   ((record-table-name table-defs)
-    (let* ((record-fields-macro-name (lutil:atom-cat
-                                       'fields- record-table-name))
+    (let* ((record-fields-macro-name (lutil-type:atom-cat
+                                      'fields- record-table-name))
            (computed-record-fields `(,record-fields-macro-name)))
       `(mnesia:create_table
         ',record-table-name

--- a/include/mnesia-macros.lfe
+++ b/include/mnesia-macros.lfe
@@ -24,7 +24,7 @@
     * The Mnesia 'create_table' function is then called, passing the table name
       as well as the obtained fields."
   ((record-table-name '())
-    `(create-table ,record-table-name (#(type set))))
+    `(create-table ,record-table-name (list (tuple 'type 'set))))
   ((record-table-name table-defs)
     (let* ((record-fields-macro-name (lutil-type:atom-cat
                                       'fields- record-table-name))


### PR DESCRIPTION
Hi,

This PR fixes two things. First, there was a call to an undefined function which was probably forgotten in some prior lutil API reorganization. Second, I was not able to properly expand the `(create-table)` macro using the syntactic version of `(list)` and `(tuple)`. Once I used the normal versions it worked fine.