### PR TITLE
Improve the performance of take when operating on a lazy sequence.

### DIFF
--- a/include/core.lfe
+++ b/include/core.lfe
@@ -113,7 +113,7 @@
     data)
   ((x data) (when (is_list data))
     (lists:sublist data x))
-  ((x func) (when (is_function func))
+  ((x func) (when (is_function func) (is_integer x) (>= x 0))
     (take x '() (funcall func))))
 
 (defun take

--- a/include/core.lfe
+++ b/include/core.lfe
@@ -117,12 +117,10 @@
     (take x '() (funcall func))))
 
 (defun take
-  ((x acc (cons _ func)) (when (>= (length acc) x))
-    acc)
-  ((x acc (cons item func)) (when (< (length acc) x))
-    (take x
-          (++ acc `(,item))
-          (funcall func))))
+  ((0 acc _)
+    (lists:reverse acc))
+  ((x acc (cons item func))
+    (take (- x 1) (cons item acc) (funcall func))))
 
 ;; Partitioning functions
 ;;

--- a/test/lutil-core-tests.lfe
+++ b/test/lutil-core-tests.lfe
@@ -17,6 +17,7 @@
 (deftest take
   (is-equal '(1 2 3 4) (take 4 (range)))
   (is-equal '(1 2 3 4 5) (take 5 '(1 2 3 4 5 6 7 8 9 10 11 12)))
+  (is-error function_clause (take -1 (range)))
   (is-equal '(1 2 3 4 5 6 7 8 9 10 11 12) (take 'all '(1 2 3 4 5 6 7 8 9 10 11 12))))
 
 (deftest next-and-take


### PR DESCRIPTION
Before: 895ms
```
> (timer:tc #'take/2 `(10000 ,(range)))
#(895158
  (1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 ...))
```
After: 258ms
```
> (timer:tc #'take/2 `(10000 ,(range)))
#(258383
  (1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 ...))
```