### PR TITLE
Update deps and such

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-   {clj, ".*", {git, "git://github.com/lfex/clj.git", {tag, "0.4.1"}}}
+   {clj, {git, "git://github.com/lfex/clj.git", {tag, "0.4.1"}}}
   ]}.
 
 {plugins, [
@@ -15,9 +15,8 @@
      [{deps, [
         {lfe, {git, "https://github.com/rvirding/lfe.git", {tag, "v1.0.2"}}}]},
       {plugins, [
-        {'lfe-version', {git, "https://github.com/lfe-rebar3/version.git", {tag, "0.3.0"}}}
-  ]}
-      ]},
+        {'lfe-version', {git, "https://github.com/lfe-rebar3/version.git", {tag, "0.3.0"}}}]}
+     ]},
    {test,
      [{deps,
         [{ltest, {git, "https://github.com/lfex/ltest.git", {tag, "0.8.2"}}}]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,12 @@
+[{<<"clj">>,
+  {git,"git://github.com/lfex/clj.git",
+       {ref,"b67b6ab26385593a3c4daf422fd4f4c64e77f7f3"}},
+  0},
+ {<<"kla">>,
+  {git,"git://github.com/lfex/kla.git",
+       {ref,"750ddfa4022ff45d053c35cf7352dfbde16a52f5"}},
+  1},
+ {<<"lfe-version">>,
+  {git,"https://github.com/lfe-rebar3/version.git",
+       {ref,"76919956b78112b86bbe5972ffc136741d708f10"}},
+  2}].

--- a/src/lutil-math.lfe
+++ b/src/lutil-math.lfe
@@ -1,6 +1,7 @@
 (defmodule lutil-math
   (export all))
 
+;; N.B. This is necessary for lutil-math-tests.
 (include-lib "clj/include/predicates.lfe")
 
 (defun floor (x)

--- a/test/lutil-file-tests.lfe
+++ b/test/lutil-file-tests.lfe
@@ -77,12 +77,14 @@
     "../lfe-reveal-js/deps/yaws"
     "deps/lfe"))
 
-(deftest check-deps
+;; TODO: Rethink this
+(deftestskip check-deps
   (is-equal
     (expected-checked-subdirs)
     (lutil-file:check-deps (get-test-subdirs))))
 
-(deftest filtered-deps
+;; TODO: Rethink this
+(deftestskip filtered-deps
   (is-equal
     (expected-filtered-subdirs)
     (lutil-file:filter-deps (get-test-subdirs))))

--- a/test/lutil-type-tests.lfe
+++ b/test/lutil-type-tests.lfe
@@ -2,7 +2,6 @@
   (behaviour ltest-unit)
   (export all))
 
-(include-lib "clj/include/predicates.lfe")
 (include-lib "ltest/include/ltest-macros.lfe")
 
 (deftest add-tuples


### PR DESCRIPTION
Update deps, clean up/annotate includes, skip tests that are dependent on a specific filesystem.

TODO: Consider rewriting `lutil-file-tests:{check,filtered}-deps_test/0` to be universally valid.